### PR TITLE
Use http when linking to superior-coin.com

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 
 - Nathan Senn
 - Michael Senn
-- Web: [superior-coin.com](https://superior-coin.com)
+- Web: [superior-coin.com](http://superior-coin.com)
 - BCT: [BitCoinTalk](https://bitcointalk.org/index.php?topic=2088169.0)
 - Mail: [admin@Superior-coin.com](mailto:admin@Superior-coin.com)
 - Github: [https://github.com/TheSuperiorCoin/TheSuperiorCoin](https://github.com/TheSuperiorCoin/TheSuperiorCoin)

--- a/contrib/snap/snapcraft.yaml
+++ b/contrib/snap/snapcraft.yaml
@@ -1,6 +1,6 @@
 name: superior
 version: 0.10.2-1
-summary: "SuperiorCoin: the secure, private, untraceable cryptocurrency https://superior-coin.com"
+summary: "SuperiorCoin: the secure, private, untraceable cryptocurrency http://superior-coin.com"
 description: |
     Superior is a private, secure, untraceable, decentralised digital currency.
     You are your bank, you control your funds, and nobody can trace your transfers


### PR DESCRIPTION
This should be temporary; we plan to get https working on the server soon.